### PR TITLE
wrapping variables in quotes for bash export

### DIFF
--- a/internal/gorson/bash/bash.go
+++ b/internal/gorson/bash/bash.go
@@ -23,7 +23,7 @@ func ParamsToShell(parameters map[string]string) string {
 	for _, key := range keys {
 		// TODO do we need to do extra escaping here?
 		v := parameters[key]
-		lines = append(lines, "export "+key+"="+v)
+		lines = append(lines, "export "+key+"=\""+v+"\"")
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/gorson/bash/bash_test.go
+++ b/internal/gorson/bash/bash_test.go
@@ -18,9 +18,9 @@ var testpairs = []testpair{
 			"beta":  "the_beta_value",
 			"delta": "the_delta_value",
 		},
-		expected: `export alpha=the_alpha_value
-export beta=the_beta_value
-export delta=the_delta_value`,
+		expected: `export alpha="the_alpha_value"
+export beta="the_beta_value"
+export delta="the_delta_value"`,
 	},
 }
 


### PR DESCRIPTION
Was getting the below error. Seems as though this is solved if the variable is wrapped in quotations.

```
root@a8f5bee1054b:/app# source <(gorson load /app/test.json)
bash: /dev/fd/63: line 1: syntax error near unexpected token `('
bash: /dev/fd/63: line 1: `export SECRET_KEY=s3cr3t(k@y(f0r+l!f5'
```

This should be fixed by wrapping all the variables in quotations.