### PR TITLE
release 1.0.0

### DIFF
--- a/internal/gorson/version/version.go
+++ b/internal/gorson/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is current gorson version
-const Version = "0.3.0"
+const Version = "1.0.0"


### PR DESCRIPTION
using a major version change because of breaking change in
https://github.com/pbs/gorson/pull/16
(removing region argument, requiring AWS_REGION instead)

1.0.0 doesn't imply anything about support, although we will use
semantic versioning - this is still an experimental, unsupported library.