### PR TITLE
Updating README references to versions to the latest value

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,20 +76,20 @@ Currently gorson ships binaries for OS X and Linux 64bit systems. You can downlo
 ## OS X
 
 ```
-$ wget https://github.com/pbs/gorson/releases/download/0.0.1/gorson-0.0.1-darwin-amd64
+$ wget https://github.com/pbs/gorson/releases/download/4.1.0/gorson-4.1.0-darwin-amd64
 ```
 
 ## Linux
 
 Download the binary
 ```
-$ wget https://github.com/pbs/gorson/releases/download/0.0.1/gorson-0.0.1-linux-amd64
+$ wget https://github.com/pbs/gorson/releases/download/4.1.0/gorson-4.1.0-linux-amd64
 ```
 
 Move the binary to an installation path, make it executable, and add to path
 ```
 mkdir -p /opt/gorson/bin
-mv gorson-0.0.1-linux-amd64 /opt/gorson/bin/gorson
+mv gorson-4.1.0-linux-amd64 /opt/gorson/bin/gorson
 chmod +x /opt/gorson/bin/gorson
 export PATH="$PATH:/opt/gorson/bin"
 ```


### PR DESCRIPTION
I don't know if you want this handled with some fancy method that will have the README automatically update with the newest release value, or to just `x.x.x` it to ensure that it breaks without specifying release.

I just consistently fail to remember to update that value and get confused when it doesn't work.