### PR TITLE
Fixing env Formatting

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -29,8 +29,8 @@ func get(path string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		var re = regexp.MustCompile(`(\w*):\s`)
-		fmt.Println(re.ReplaceAllString(string(serialized), "${1}="))
+		var re = regexp.MustCompile(`(\w*):\s"?([^\n"]*)"?`)
+		fmt.Println(re.ReplaceAllString(string(serialized), "${1}='${2}'"))
 
 	} else if format == "json" {
 		marshalled := json.Marshal(pms)


### PR DESCRIPTION
We're looking to use gorson as a convenient way to populate a .env file for a Craft application and ran into issues with parameters whose values contained spaces. I'm not sure you guys want this functionality to work this way, but this adjustment will make it so that all values in an env are surrounded with single quotes.

I'm not super familiar with Go, so my testing consisted of just building the binary locally and trying out the parameters I ran into trouble with. Please let me know if you'd like me to go through any extra procedures or whatnot to make this acceptable.