### PR TITLE
Release 9 Docs Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ wget https://github.com/pbs/gorson/releases/download/6/gorson-6-darwin-amd64
 Download the binary
 
 ```bash
-wget https://github.com/pbs/gorson/releases/download/6/gorson-6-darwin-amd64
+wget https://github.com/pbs/gorson/releases/download/9/gorson-9-darwin-amd64
 ```
 
 Move the binary to an installation path, make it executable, and add to path
 
 ```bash
 mkdir -p /opt/gorson/bin
-mv gorson-6-linux-amd64 /opt/gorson/bin/gorson
+mv gorson-9-linux-amd64 /opt/gorson/bin/gorson
 chmod +x /opt/gorson/bin/gorson
 export PATH="$PATH:/opt/gorson/bin"
 ```
@@ -135,13 +135,13 @@ asdf list-all gorson
 Install a particular version
 
 ```bash
-asdf install gorson 6
+asdf install gorson 8
 ```
 
 Make a particular version your default
 
 ```bash
-asdf global gorson 6
+asdf global gorson 8
 ```
 
 # Notes

--- a/internal/gorson/version/version.go
+++ b/internal/gorson/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is current gorson version
-const Version = "8"
+const Version = "9"


### PR DESCRIPTION
Merging in `release/9` into main so that the `README.md` displays the proper values for installation, and so that the `internal/gorson/version/version.go` is updated for the next release.

We should probably automate this whole process a bit more. I was looking into https://github.com/semantic-release/semantic-release recently.