### PR TITLE
#63 - Adding ARM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ If you would prefer the output of commands to be colorless, append `--no-color`.
 
 # Installation
 
-Currently gorson ships binaries for OS X and Linux 64bit systems. You can download the latest release from [GitHub](https://github.com/pbs/gorson/releases)
+Currently gorson ships binaries for MacOS and Linux 64bit systems. You can download the latest release from [GitHub](https://github.com/pbs/gorson/releases)
 
-## OS X
+## MacOS
 
 ```bash
 wget https://github.com/pbs/gorson/releases/download/10/gorson-10-darwin-amd64
@@ -106,6 +106,12 @@ Download the binary
 ```bash
 wget https://github.com/pbs/gorson/releases/download/10/gorson-10-linux-amd64
 ```
+
+## ARM
+
+For either MacOS or Linux, replace the `amd64` with `arm64` above.
+
+## Install the binary
 
 Move the binary to an installation path, make it executable, and add to path
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -20,22 +20,23 @@ docker build -t gorson_builder -f Dockerfile.build.alpine .
 >&2 echo "compiling binaries for release"
 # for each of our target platforms we use the gorson_builder
 #   docker container to compile a binary of our application
-for platform in darwin linux; do \
-    binary_name="gorson-${VERSION}-${platform}-amd64"
-    >&2 echo "compiling $binary_name"
+for architecture in amd64 arm64; do
+    for platform in darwin linux; do \
+        binary_name="gorson-${VERSION}-${platform}-${architecture}"
+        >&2 echo "compiling $binary_name"
 
-    # * GOOS is the target operating system
-    # * GOARCH is the target processor architecture
-    #     (we only compile for amd64 systems)
-    #     see https://golang.org/cmd/go/#hdr-Environment_variables
-    # * CGO_ENABLED controls whether the go compiler allows us to
-    #     import C packages (we don't do this, so we set it to 0 to turn CGO off)
-    #     see https://golang.org/cmd/cgo/
-    docker run --rm \
-    -v "${PWD}":/app \
-    -e "GOOS=$platform" \
-    -e "GOARCH=amd64" \
-    -e "CGO_ENABLED=0" \
-    gorson_builder \
-        go build -o "bin/$binary_name"
+        # * GOOS is the target operating system
+        # * GOARCH is the target processor architecture
+        #     see https://golang.org/cmd/go/#hdr-Environment_variables
+        # * CGO_ENABLED controls whether the go compiler allows us to
+        #     import C packages (we don't do this, so we set it to 0 to turn CGO off)
+        #     see https://golang.org/cmd/cgo/
+        docker run --rm \
+        -v "${PWD}":/app \
+        -e "GOOS=${platform}" \
+        -e "GOARCH=${architecture}" \
+        -e "CGO_ENABLED=0" \
+        gorson_builder \
+            go build -o "bin/$binary_name"
+    done
 done

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,7 +21,7 @@ docker build -t gorson_builder -f Dockerfile.build.alpine .
 # for each of our target platforms we use the gorson_builder
 #   docker container to compile a binary of our application
 for architecture in amd64 arm64; do
-    for platform in darwin linux; do \
+    for platform in darwin linux; do
         binary_name="gorson-${VERSION}-${platform}-${architecture}"
         >&2 echo "compiling $binary_name"
 

--- a/scripts/docker-release.sh
+++ b/scripts/docker-release.sh
@@ -19,16 +19,17 @@ VERSION=$(grep -E -o '[0-9]+\.[0-9a-z.\-]+' ./internal/gorson/version/version.go
 # for each of our target platforms we use the gorson_builder
 #   docker container to compile a binary of our application
 >&2 echo "compiling binaries for release"
-for platform in darwin linux; do \
-    binary_name="gorson-${VERSION}-${platform}-amd64"
-    >&2 echo "compiling $binary_name"
+for architecture in amd64 arm64; do
+    for platform in darwin linux; do
+        binary_name="gorson-${VERSION}-${platform}-${architecture}"
+        >&2 echo "compiling $binary_name"
 
-    # * GOOS is the target operating system
-    # * GOARCH is the target processor architecture
-    #     (we only compile for amd64 systems)
-    #     see https://golang.org/cmd/go/#hdr-Environment_variables
-    # * CGO_ENABLED controls whether the go compiler allows us to
-    #     import C packages (we don't do this, so we set it to 0 to turn CGO off)
-    #     see https://golang.org/cmd/cgo/
-    GOOS=$platform GOARCH=amd64 CGO_ENABLED=0 go build -o "bin/$binary_name"
+        # * GOOS is the target operating system
+        # * GOARCH is the target processor architecture
+        #     see https://golang.org/cmd/go/#hdr-Environment_variables
+        # * CGO_ENABLED controls whether the go compiler allows us to
+        #     import C packages (we don't do this, so we set it to 0 to turn CGO off)
+        #     see https://golang.org/cmd/cgo/
+        GOOS=$platform GOARCH=$architecture CGO_ENABLED=0 go build -o "bin/$binary_name"
+    done
 done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,7 +24,7 @@ NEW=$(( CURRENT + 1))
 # Internal gorson version
 find_and_replace "s/$CURRENT/$NEW/g" ./internal/gorson/version/version.go
 # Binary version
-find_and_replace "s/gorson-$CURRENT-([^-]+)-amd64/gorson-$NEW-\1-amd64/g" README.md
+find_and_replace "s/gorson-$CURRENT-([^-]+)-/gorson-$NEW-\1-/g" README.md
 # asdf version
 find_and_replace "s/gorson $CURRENT/gorson $NEW/g" README.md
 # GitHub release version


### PR DESCRIPTION
This kind of just worked first try... 👻 

I confirmed that the binaries built right, and that I can run `gorson version` on them all within the M1 host for the MacOS binaries and within an Alpine container for the Linux binaries.

I wasn't able to confirm that they correctly pull from SSM, as AWS is down right now.

I also cleaned up the docs a little while adding info on how to install them.

Closes #63 